### PR TITLE
Add in SSL binary to allow for running tests

### DIFF
--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -19,5 +19,34 @@ jobs:
         cp -r ../base-files/. /opt/caslab/lib/pt/
         export PATH=$PATH:$(pwd)/../binaries
         make scanner
+        ssl parser/scanner.ssl
       working-directory: ./pt
+    - name: Test scanner (simpleTest.qu)
+      run: |
+        chmod +x ../binaries/ptc
+        chmod +x ../binaries/ssl
+        mkdir -p /opt/caslab/lib/pt
+        cp -r ../base-files/. /opt/caslab/lib/pt/
+        export PATH=$PATH:$(pwd)/../binaries
+        make scanner
+        
+        cd test/
+        cp simpleTest.qu simpleTest.pt
+        timeout 3 ssltrace "ptc -o1 -t1 -L lib/pt simpleTest.pt" lib/pt/scan.def -e; echo exit=$
+      working-directory: ./pt
+    - name: Test scanner (test.qu)
+      run: |
+        chmod +x ../binaries/ptc
+        chmod +x ../binaries/ssl
+        mkdir -p /opt/caslab/lib/pt
+        cp -r ../base-files/. /opt/caslab/lib/pt/
+        export PATH=$PATH:$(pwd)/../binaries
+        make scanner
+        
+        cd test/
+        cp test.qu test.pt
+        timeout 3 ssltrace "ptc -o1 -t1 -L lib/pt test.pt" lib/pt/scan.def -e; echo exit=$
+      working-directory: ./pt
+
+
 


### PR DESCRIPTION
This also fixes a bug whereby the check would not error if the SSL token definitions were out of date